### PR TITLE
refactor: use camelCase and reorder sections

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -5,29 +5,31 @@ indicator("카르마RSI", overlay=true, max_bars_back=500)
 // [입력값] INPUTS
 // ═══════════════════════════════════════════════════════════════
 // 채널
-groupCHANNEL = "CHANNEL"
-int   length        = input.int(150, "채널 길이", minval=2, group=groupCHANNEL)
-float channel_width = input.float(1.5, "채널 폭", step=0.1, minval=0.1, group=groupCHANNEL)
-bool  mid_disp      = input.bool(true, "50선", inline="mid", group=groupCHANNEL)
-bool  fill_band     = input.bool(true, "백그라운드", inline="mid", group=groupCHANNEL)
-color col_up        = input.color(#a7abb9, "라인 색상: 상단", group=groupCHANNEL, inline="Col")
-color col_mid       = input.color(color.gray, "중앙", group=groupCHANNEL, inline="Col")
-color col_low       = input.color(#a7abb9, "하단", group=groupCHANNEL, inline="Col")
+groupChannel = "CHANNEL"
+int   length        = input.int(150, "채널 길이", minval=2, group=groupChannel)
+float channelWidth  = input.float(1.5, "채널 폭", step=0.1, minval=0.1, group=groupChannel)
+bool  midDisp       = input.bool(true, "50선", inline="mid", group=groupChannel)
+bool  fillBand      = input.bool(true, "백그라운드", inline="mid", group=groupChannel)
+color colUp         = input.color(#a7abb9, "라인 색상: 상단", group=groupChannel, inline="Col")
+color colMid        = input.color(color.gray, "중앙", group=groupChannel, inline="Col")
+color colLow        = input.color(#a7abb9, "하단", group=groupChannel, inline="Col")
 
 // RSI
-groupRSI = "RSI"
-int   length_rsi      = input.int(14, "길이", inline="rsi", group=groupRSI)
-color osc_col_base    = input.color(color.rgb(161, 0, 182), "", inline="rsi", group=groupRSI)
-int   rsi_transp      = input.int(30, "RSI 선 투명도 (0~100)", minval=0, maxval=100, group=groupRSI)
-int   upper_threshold = input.int(70, "상단 기준선 (%)", minval=50, maxval=100, step=1, inline="th", group=groupRSI)
-bool  show_threshold_labels = input.bool(true, "기준선 라벨", inline="th", group=groupRSI)
-bool  sig_disp        = input.bool(true, "Signal", inline="sig", group=groupRSI)
-int   length_sig      = input.int(14, "", inline="sig", group=groupRSI)
-color sig_line        = input.color(color.rgb(255, 0, 0), "", inline="sig", group=groupRSI)
+groupRsi = "RSI"
+int   lengthRsi        = input.int(14, "길이", inline="rsi", group=groupRsi)
+color oscColBase       = input.color(color.rgb(161, 0, 182), "", inline="rsi", group=groupRsi)
+int   rsiTransp        = input.int(30, "RSI 선 투명도 (0~100)", minval=0, maxval=100, group=groupRsi)
+int   upperThreshold   = input.int(70, "상단 기준선 (%)", minval=50, maxval=100, step=1, inline="th", group=groupRsi)
+bool  showThresholdLabels = input.bool(true, "기준선 라벨", inline="th", group=groupRsi)
+bool  sigDisp          = input.bool(true, "Signal", inline="sig", group=groupRsi)
+int   lengthSig        = input.int(14, "", inline="sig", group=groupRsi)
+color sigLine          = input.color(color.rgb(255, 0, 0), "", inline="sig", group=groupRsi)
 
 // ═══════════════════════════════════════════════════════════════
+// 계산 로직
+// ═══════════════════════════════════════════════════════════════
 // 로그 회귀 함수
-f_log_regression(src, len) =>
+fLogRegression(src, len) =>
     // 최근 len개 구간: i=0(현재) ~ i=len-1(과거)
     float sumX = 0.0, sumY = 0.0, sumXSqr = 0.0, sumXY = 0.0
     for i = 0 to len - 1
@@ -42,164 +44,163 @@ f_log_regression(src, len) =>
     [slope, intercept]
 
 // 현재 bar에서 len 구간이 충분한지
-bool bar_ready = bar_index >= length
+bool barReady = bar_index >= length
 
 // 회귀선 및 채널 계산(충분한 바가 있어야 함)
 float slope = na
 float intercept = na
-float reg_start = na
-float reg_end = na
+float regStart = na
+float regEnd = na
 float dev = na
-float upper_start = na
-float upper_end = na
-float lower_start = na
-float lower_end = na
+float upperStart = na
+float upperEnd = na
+float lowerStart = na
+float lowerEnd = na
 
-if bar_ready
-    [slope, intercept] = f_log_regression(close, length)  // ← 다중 할당은 '=' 사용
+if barReady
+    [slope, intercept] = fLogRegression(close, length)  // ← 다중 할당은 '=' 사용
     // per 를 1..length 로 잡았으므로,
     // start(과거) = per=length, end(현재) = per=1
-    reg_start := math.exp(intercept + slope * length)
-    reg_end   := math.exp(intercept + slope * 1.0)
+    regStart := math.exp(intercept + slope * length)
+    regEnd   := math.exp(intercept + slope * 1.0)
     dev := ta.stdev(close, length)
-    upper_start := reg_start + dev * channel_width
-    upper_end   := reg_end   + dev * channel_width
-    lower_start := reg_start - dev * channel_width
-    lower_end   := reg_end   - dev * channel_width
+    upperStart := regStart + dev * channelWidth
+    upperEnd   := regEnd   + dev * channelWidth
+    lowerStart := regStart - dev * channelWidth
+    lowerEnd   := regEnd   - dev * channelWidth
 
-// ═══════════════════════════════════════════════════════════════
-// [상태 핸들] 라인/필/폴리라인/라벨
-var line mid_line   = na
-var line upper_line = na
-var line lower_line = na
-var linefill ch_fill = na
-
-var polyline pl_rsi = na
-var polyline pl_sig = na
-
-var label lbl_rsi = na
-var label lbl_lo  = na
-var label lbl_hi  = na
-
-// ═══════════════════════════════════════════════════════════════
-// 채널 라인 생성/업데이트
-if bar_ready and not na(dev)
-    // 중앙선(표시 토글 안전 처리)
-    if mid_disp
-        if na(mid_line)
-            mid_line := line.new(bar_index[length], reg_start, bar_index, reg_end, xloc=xloc.bar_index, color=col_mid, style=line.style_dashed)
-        else
-            line.set_xy1(mid_line, bar_index[length], reg_start)
-            line.set_xy2(mid_line, bar_index,       reg_end)
-            line.set_color(mid_line, col_mid)
-    else
-        if not na(mid_line)
-            line.delete(mid_line)
-            mid_line := na
-
-    // 상단/하단 채널
-    if na(upper_line)
-        upper_line := line.new(bar_index[length], upper_start, bar_index, upper_end, xloc=xloc.bar_index, color=col_up, width=2)
-    else
-        line.set_xy1(upper_line, bar_index[length], upper_start)
-        line.set_xy2(upper_line, bar_index,         upper_end)
-        line.set_color(upper_line, col_up)
-    if na(lower_line)
-        lower_line := line.new(bar_index[length], lower_start, bar_index, lower_end, xloc=xloc.bar_index, color=col_low, width=2)
-    else
-        line.set_xy1(lower_line, bar_index[length], lower_start)
-        line.set_xy2(lower_line, bar_index,         lower_end)
-        line.set_color(lower_line, col_low)
-
-    // 채널 필
-    if fill_band
-        if na(ch_fill) and not na(upper_line) and not na(lower_line)
-            ch_fill := linefill.new(upper_line, lower_line, color.new(osc_col_base, 95))
-        // line 좌표는 매 bar 갱신되므로 linefill 은 1회 생성으로 충분
-    else
-        if not na(ch_fill)
-            linefill.delete(ch_fill)
-            ch_fill := na
-
-// 초기 바 부족/na 처리: 만들어진 라인은 제거
-if not bar_ready or na(dev)
-    if not na(mid_line)
-        line.delete(mid_line)
-        mid_line := na
-    if not na(upper_line)
-        line.delete(upper_line)
-        upper_line := na
-    if not na(lower_line)
-        line.delete(lower_line)
-        lower_line := na
-    if not na(ch_fill)
-        linefill.delete(ch_fill)
-        ch_fill := na
-
-// ═══════════════════════════════════════════════════════════════
 // RSI & 시그널
-float rsi = ta.rsi(close, length_rsi)
-float sig = ta.sma(rsi,  length_sig)
-int   lower_threshold = 100 - upper_threshold
-
-// RSI 색상(입력값은 투명도 그대로 사용)
-color osc_col = color.new(osc_col_base, rsi_transp)
+float rsi = ta.rsi(close, lengthRsi)
+float sig = ta.sma(rsi,  lengthSig)
+int   lowerThreshold = 100 - upperThreshold
 
 // 채널 축 ↔ RSI(0~100) 매핑
-// - 각 bar에서 하단 기준선 값: lower_end(현재)에서 과거로 갈수록 선형 보간
-float lower_slope = na
+// - 각 bar에서 하단 기준선 값: lowerEnd(현재)에서 과거로 갈수록 선형 보간
+float lowerSlope = na
 float step = na
-if bar_ready and not na(dev)
-    lower_slope := (lower_start - lower_end) / (length - 1)
-    step        := (upper_end   - lower_end) / (upper_threshold - lower_threshold)  // 1 RSI 포인트당 가격 변화량
+if barReady and not na(dev)
+    lowerSlope := (lowerStart - lowerEnd) / (length - 1)
+    step       := (upperEnd   - lowerEnd) / (upperThreshold - lowerThreshold)  // 1 RSI 포인트당 가격 변화량
 
 // 매핑 함수 (파라미터 타입 기입/ '=' 금지)
-f_map_to_price_at(idx, r) =>
+fMapToPriceAt(idx, r) =>
     // idx: i=0(현재) .. i=length-1(과거)
-    float base = lower_end + lower_slope * idx
-    base + step * (r - lower_threshold)
+    float base = lowerEnd + lowerSlope * idx
+    base + step * (r - lowerThreshold)
 
 // ═══════════════════════════════════════════════════════════════
+// 모습
+// ═══════════════════════════════════════════════════════════════
+color oscCol = color.new(oscColBase, rsiTransp)
+
+var line midLine   = na
+var line upperLine = na
+var line lowerLine = na
+var linefill chFill = na
+
+var polyline plRsi = na
+var polyline plSig = na
+
+var label lblRsi = na
+var label lblLo  = na
+var label lblHi  = na
+
+// ═══════════════════════════════════════════════════════════════
+// 랜더링
+// ═══════════════════════════════════════════════════════════════
+if barReady and not na(dev)
+    // 중앙선(표시 토글 안전 처리)
+    if midDisp
+        if na(midLine)
+            midLine := line.new(bar_index[length], regStart, bar_index, regEnd, xloc=xloc.bar_index, color=colMid, style=line.style_dashed)
+        else
+            line.set_xy1(midLine, bar_index[length], regStart)
+            line.set_xy2(midLine, bar_index,       regEnd)
+            line.set_color(midLine, colMid)
+    else
+        if not na(midLine)
+            line.delete(midLine)
+            midLine := na
+
+    // 상단/하단 채널
+    if na(upperLine)
+        upperLine := line.new(bar_index[length], upperStart, bar_index, upperEnd, xloc=xloc.bar_index, color=colUp, width=2)
+    else
+        line.set_xy1(upperLine, bar_index[length], upperStart)
+        line.set_xy2(upperLine, bar_index,         upperEnd)
+        line.set_color(upperLine, colUp)
+    if na(lowerLine)
+        lowerLine := line.new(bar_index[length], lowerStart, bar_index, lowerEnd, xloc=xloc.bar_index, color=colLow, width=2)
+    else
+        line.set_xy1(lowerLine, bar_index[length], lowerStart)
+        line.set_xy2(lowerLine, bar_index,         lowerEnd)
+        line.set_color(lowerLine, colLow)
+
+    // 채널 필
+    if fillBand
+        if na(chFill) and not na(upperLine) and not na(lowerLine)
+            chFill := linefill.new(upperLine, lowerLine, color.new(oscColBase, 95))
+        // line 좌표는 매 bar 갱신되므로 linefill 은 1회 생성으로 충분
+    else
+        if not na(chFill)
+            linefill.delete(chFill)
+            chFill := na
+
+// 초기 바 부족/na 처리: 만들어진 라인은 제거
+if not barReady or na(dev)
+    if not na(midLine)
+        line.delete(midLine)
+        midLine := na
+    if not na(upperLine)
+        line.delete(upperLine)
+        upperLine := na
+    if not na(lowerLine)
+        line.delete(lowerLine)
+        lowerLine := na
+    if not na(chFill)
+        linefill.delete(chFill)
+        chFill := na
+
 // 폴리라인 & 라벨(마지막 바에서만 재그리기 → 성능/누수 관리)
-if barstate.islast and bar_ready and not na(dev)
+if barstate.islast and barReady and not na(dev)
     // 이전 도형/라벨 정리 (각 문장 분리)
-    if not na(pl_rsi)
-        polyline.delete(pl_rsi)
-        pl_rsi := na
-    if not na(pl_sig)
-        polyline.delete(pl_sig)
-        pl_sig := na
-    if not na(lbl_rsi)
-        label.delete(lbl_rsi)
-        lbl_rsi := na
-    if not na(lbl_lo)
-        label.delete(lbl_lo)
-        lbl_lo := na
-    if not na(lbl_hi)
-        label.delete(lbl_hi)
-        lbl_hi := na
+    if not na(plRsi)
+        polyline.delete(plRsi)
+        plRsi := na
+    if not na(plSig)
+        polyline.delete(plSig)
+        plSig := na
+    if not na(lblRsi)
+        label.delete(lblRsi)
+        lblRsi := na
+    if not na(lblLo)
+        label.delete(lblLo)
+        lblLo := na
+    if not na(lblHi)
+        label.delete(lblHi)
+        lblHi := na
 
     // RSI 폴리라인
-    points_rsi = array.new<chart.point>()
+    pointsRsi = array.new<chart.point>()
     for i = 0 to length - 1
-        float y = f_map_to_price_at(i, rsi[i])
-        array.push(points_rsi, chart.point.from_index(bar_index[i], y))
-    pl_rsi := polyline.new(points_rsi, line_color=osc_col, closed=false, force_overlay=true, line_width=4)
+        float y = fMapToPriceAt(i, rsi[i])
+        array.push(pointsRsi, chart.point.from_index(bar_index[i], y))
+    plRsi := polyline.new(pointsRsi, line_color=oscCol, closed=false, force_overlay=true, line_width=4)
 
     // Signal 폴리라인 (옵션)
-    if sig_disp
-        points_sig = array.new<chart.point>()
+    if sigDisp
+        pointsSig = array.new<chart.point>()
         for i = 0 to length - 1
-            float yS = f_map_to_price_at(i, sig[i])
-            array.push(points_sig, chart.point.from_index(bar_index[i], yS))
-        pl_sig := polyline.new(points_sig, line_color=sig_line, closed=false, force_overlay=true, line_width=2)
+            float yS = fMapToPriceAt(i, sig[i])
+            array.push(pointsSig, chart.point.from_index(bar_index[i], yS))
+        plSig := polyline.new(pointsSig, line_color=sigLine, closed=false, force_overlay=true, line_width=2)
 
     // 라벨: 현재값/기준선 (옵션)
-    float y_now = f_map_to_price_at(0, rsi)
-    lbl_rsi := label.new(bar_index, y_now,
+    float yNow = fMapToPriceAt(0, rsi)
+    lblRsi := label.new(bar_index, yNow,
          "카르마 RSI: " + str.tostring(rsi, "#.##"),
          style=label.style_label_left, textcolor=chart.fg_color, color=color.new(color.black, 100))
 
-    if show_threshold_labels
-        lbl_lo := label.new(bar_index, lower_end, str.tostring(lower_threshold, "##.#"), style=label.style_label_left, textcolor=chart.fg_color, color=color.new(color.black, 100))
-        lbl_hi := label.new(bar_index, upper_end, str.tostring(upper_threshold, "##.#"), style=label.style_label_left, textcolor=chart.fg_color, color=color.new(color.black, 100))
+    if showThresholdLabels
+        lblLo := label.new(bar_index, lowerEnd, str.tostring(lowerThreshold, "##.#"), style=label.style_label_left, textcolor=chart.fg_color, color=color.new(color.black, 100))
+        lblHi := label.new(bar_index, upperEnd, str.tostring(upperThreshold, "##.#"), style=label.style_label_left, textcolor=chart.fg_color, color=color.new(color.black, 100))


### PR DESCRIPTION
## Summary
- rename variables to camelCase for consistency
- reorder script into inputs, calculation logic, appearance, and rendering sections

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6444b80e08325a7f9a5805609d193