### PR TITLE
refactor: reuse polyline arrays

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -180,6 +180,8 @@ var polyline pl_sig = na
 var label    lbl_rsi = na
 var label    lbl_lo  = na
 var label    lbl_hi  = na
+var array<chart.point> points_rsi = array.new<chart.point>()
+var array<chart.point> points_sig = array.new<chart.point>()
 
 // 마지막 바에서만 폴리라인/라벨 갱신
 if barstate.islast and bar_ready and not na(dev)
@@ -196,7 +198,7 @@ if barstate.islast and bar_ready and not na(dev)
         label.delete(lbl_hi),  lbl_hi  := na
 
     // RSI 폴리라인
-    points_rsi = array.new<chart.point>()
+    array.clear(points_rsi)
     for i = 0 to length - 1
         float y = f_map_to_price_at(i, rsi[i])
         array.push(points_rsi, chart.point.from_index(bar_index[i], y))
@@ -204,7 +206,7 @@ if barstate.islast and bar_ready and not na(dev)
 
     // 시그널 폴리라인
     if sig_disp
-        points_sig = array.new<chart.point>()
+        array.clear(points_sig)
         for i = 0 to length - 1
             float yS = f_map_to_price_at(i, sig[i])
             array.push(points_sig, chart.point.from_index(bar_index[i], yS))


### PR DESCRIPTION
## Summary
- reuse polyline point arrays with `var`
- clear arrays instead of reallocating on every bar update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b704ed09088325a6169460c1f28892