### PR TITLE
Add slope percentage label to regression channel

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -82,6 +82,7 @@ float upper_start = na
 float upper_end   = na
 float lower_start = na
 float lower_end   = na
+float slopePct    = na
 
 if bar_ready
     [slope, intercept] = f_log_regression(close, length)
@@ -92,12 +93,16 @@ if bar_ready
     upper_end   := reg_end   + dev * channel_width
     lower_start := reg_start - dev * channel_width
     lower_end   := reg_end   - dev * channel_width
+    // slope returned by f_log_regression is log(past/current)
+    // convert to percent change from past to current (positive = uptrend)
+    slopePct    := (math.exp(-slope) - 1) * 100
 
 // 라인/필 핸들
 var line     mid_line  = na
 var line     upper_line = na
 var line     lower_line = na
 var linefill ch_fill    = na
+var label    lblSlope   = na
 
 // 채널 라인/필 업데이트
 if bar_ready and not na(dev)
@@ -132,6 +137,16 @@ if bar_ready and not na(dev)
         line.set_xy2(lower_line, bar_index,         lower_end)
         line.set_color(lower_line, col_low)
 
+    // 슬로프 라벨
+    int    centerX   = bar_index - length / 2
+    float  centerY   = (upper_start + upper_end) / 2 + dev * 0.1
+    string slopeText = str.tostring(slopePct, "#.##") + "%"
+    if na(lblSlope)
+        lblSlope := label.new(centerX, centerY, slopeText, xloc=xloc.bar_index)
+    else
+        label.set_xy(lblSlope, centerX, centerY)
+        label.set_text(lblSlope, slopeText)
+
     // 채움
     if fill_band
         if na(ch_fill) and not na(upper_line) and not na(lower_line)
@@ -151,6 +166,8 @@ if not bar_ready or na(dev)
         line.delete(lower_line), lower_line := na
     if not na(ch_fill)
         linefill.delete(ch_fill), ch_fill := na
+    if not na(lblSlope)
+        label.delete(lblSlope), lblSlope := na
 
 // ═══════════════════════════════════════════════════════════════
 // [RSI & 시그널] RSI / SIGNAL


### PR DESCRIPTION
## Summary
- compute slope percentage for regression channel and render label displaying the percentage
- remove slope label when channel is not available
- ensure slope percent sign matches channel direction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b838fd9970832582db26f06646798c