### PR TITLE
Show price change per minute in regression channel

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -82,7 +82,7 @@ float upper_start = na
 float upper_end   = na
 float lower_start = na
 float lower_end   = na
-float slopePct    = na
+float deltaPricePerMinute = na
 
 if bar_ready
     [slope, intercept] = f_log_regression(close, length)
@@ -93,9 +93,7 @@ if bar_ready
     upper_end   := reg_end   + dev * channel_width
     lower_start := reg_start - dev * channel_width
     lower_end   := reg_end   - dev * channel_width
-    // slope returned by f_log_regression is log(past/current)
-    // convert to percent change from past to current (positive = uptrend)
-    slopePct    := (math.exp(-slope) - 1) * 100
+    deltaPricePerMinute := (reg_end - reg_start) / ((time - time[length - 1]) / 60000.0)
 
 // 라인/필 핸들
 var line     mid_line  = na
@@ -140,7 +138,7 @@ if bar_ready and not na(dev)
     // 슬로프 라벨
     int    centerX   = bar_index - length / 2
     float  centerY   = (upper_start + upper_end) / 2 + dev * 0.1
-    string slopeText = str.tostring(slopePct, "#.##") + "%"
+    string slopeText = str.tostring(deltaPricePerMinute, format.mintick) + " KRW/min"
     if na(lblSlope)
         lblSlope := label.new(centerX, centerY, slopeText, xloc=xloc.bar_index)
     else


### PR DESCRIPTION
## Summary
- calculate delta price per minute from regression start/end
- show price change per minute label instead of slope percent

## Testing
- `find . -maxdepth 2 -name '*test*'`


------
https://chatgpt.com/codex/tasks/task_e_68b8475c7884832593aa982455be8529