### PR TITLE
Show channel percent change

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -82,7 +82,7 @@ float upper_start = na
 float upper_end   = na
 float lower_start = na
 float lower_end   = na
-float deltaPricePerMinute = na
+float channelPercentChange = na
 
 if bar_ready
     [slope, intercept] = f_log_regression(close, length)
@@ -94,9 +94,8 @@ if bar_ready
     lower_start := reg_start - dev * channel_width
     lower_end   := reg_end   - dev * channel_width
     // slope returned by f_log_regression is log(past/current)
-    // compute price change per minute
-    float deltaPricePerBar = (reg_end - reg_start) / (length - 1)
-    deltaPricePerMinute := deltaPricePerBar / (timeframe.in_seconds(timeframe.period) / 60.0)
+    // compute percentage price change over the channel
+    channelPercentChange := (reg_end - reg_start) / reg_start * 100
 
 // 라인/필 핸들
 var line     mid_line  = na
@@ -141,8 +140,7 @@ if bar_ready and not na(dev)
     // 슬로프 라벨
     int    centerX   = bar_index - length / 2
     float  centerY   = (upper_start + upper_end) / 2 + dev * 0.1
-    string curr = syminfo.currency
-    string slopeText = str.tostring(deltaPricePerMinute, format.mintick) + " " + curr + "/min"
+    string slopeText = str.format("{0,number,0.##}%", channelPercentChange)
     if na(lblSlope)
         lblSlope := label.new(centerX, centerY, slopeText, xloc=xloc.bar_index)
     else


### PR DESCRIPTION
## Summary
- Display channel regression slope as percentage change over channel range
- Format slope label with up to two decimal places

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86a33d43c8325885afa1caf134e72