### PR TITLE
Fix regression channel value indexing

### DIFF
--- a/카르마 RSI.pine
+++ b/카르마 RSI.pine
@@ -198,7 +198,7 @@ if bar_ready and not na(dev)
 
 // 회귀값 (idx: 0=현재..length-1=과거)
 f_reg_value_at(idx) =>
-    math.exp(intercept + slope * (channelLength - idx))
+    math.exp(intercept + slope * (1.0 + idx))
 
 // RSI→가격 매핑 (idx: 0=현재..length-1=과거)
 f_map_to_price_at(idx, r) =>


### PR DESCRIPTION
## Summary
- adjust regression value function to use forward indexing for RSI/channel alignment

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda299f420832594436f9fe749ac51